### PR TITLE
Add PiSpot Watch and PiSpot Show to Embedded Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Cross-platform build system. Continuous and IDE integration. Arduino and ARM mbe
 - [Buildroot](https://buildroot.org/) - Buildroot is a simple, efficient and easy-to-use tool to generate embedded Linux systems through cross-compilation.
 - [Mender](https://github.com/mendersoftware/mender) - Open source over-the-air (OTA) software updater for embedded Linux devices.
 - [SWUpdate](https://github.com/sbabic/swupdate) - Linux Update agent with the goal to provide an efficient and safe way to update (local, remote, multiple update strategies) an embedded system.
+- [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - A Raspberry Pi Zero W wearable with a PaPiRus e-ink display that shows WiFi hotspot vouchers. Uses SPI for the e-paper driver, systemd services, and Ansible for fleet deployment.
+- [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - A Raspberry Pi 3 HDMI kiosk that displays WiFi vouchers with weather integration and PiJuice UPS battery management. Uses GPIO/I2C for the PiJuice HAT, systemd services, and Ansible for fleet deployment.
 
 ### Courses
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Cross-platform build system. Continuous and IDE integration. Arduino and ARM mbe
 - [Buildroot](https://buildroot.org/) - Buildroot is a simple, efficient and easy-to-use tool to generate embedded Linux systems through cross-compilation.
 - [Mender](https://github.com/mendersoftware/mender) - Open source over-the-air (OTA) software updater for embedded Linux devices.
 - [SWUpdate](https://github.com/sbabic/swupdate) - Linux Update agent with the goal to provide an efficient and safe way to update (local, remote, multiple update strategies) an embedded system.
-- [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - A Raspberry Pi Zero W wearable with a PaPiRus e-ink display that shows WiFi hotspot vouchers. Uses SPI for the e-paper driver, systemd services, and Ansible for fleet deployment.
-- [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - A Raspberry Pi 3 HDMI kiosk that displays WiFi vouchers with weather integration and PiJuice UPS battery management. Uses GPIO/I2C for the PiJuice HAT, systemd services, and Ansible for fleet deployment.
+- [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable Raspberry Pi Zero with e-ink display for WiFi voucher generation.
+- [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Headless Raspberry Pi kiosk that generates WiFi vouchers and displays them on HDMI.
 
 ### Courses
 


### PR DESCRIPTION
## Summary

- Adds [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) — a Raspberry Pi Zero W wearable with PaPiRus e-ink display for WiFi hotspot voucher display (SPI, systemd, Ansible fleet deployment).
- Adds [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) — a Raspberry Pi 3 HDMI kiosk for WiFi voucher display with weather integration and PiJuice UPS battery management (GPIO/I2C, systemd, Ansible fleet deployment).

Both are real-world embedded Linux IoT devices deployed in hospitality environments.